### PR TITLE
OSX support for postfish

### DIFF
--- a/main.c
+++ b/main.c
@@ -251,6 +251,7 @@ int main(int argc, char **argv){
      its better to ignore other traps in production than to crash the
      app.  Please inform the FPU of this. */
 
+#ifndef __APPLE__
 #ifndef DEBUG
   fedisableexcept(FE_INVALID);
   fedisableexcept(FE_INEXACT);
@@ -262,6 +263,7 @@ int main(int argc, char **argv){
   feenableexcept(FE_UNDERFLOW);
   feenableexcept(FE_OVERFLOW);
 #endif 
+#endif
 
   /* Linux Altivec support has a very annoying problem; by default,
      math on denormalized floats will simply crash the program.  FFTW3

--- a/output.c
+++ b/output.c
@@ -550,10 +550,10 @@ int output_probe_monitor(void ){
     return 0;
   }
 
-  #ifdef __APPLE_
-  output_probe_monitor_pulse();
-  #else
+  #ifdef __APPLE__
   output_probe_monitor_macosx();
+  #else
+  output_probe_monitor_pulse();
   #endif
   {
     int n = monitor_entries;

--- a/output.c
+++ b/output.c
@@ -508,7 +508,7 @@ static void output_probe_monitor_ALSA(){
 
 static void output_probe_monitor_pulse(){
   /* does this AO even have pulse output? */
-  int id = ao_driver_id("pulse");
+  int id = ao_driver_id("macosx");
   if(id>=0){
     /* test open; format doesn't matter */
     ao_sample_format format={16,48000,2,AO_FMT_NATIVE,NULL};
@@ -517,6 +517,22 @@ static void output_probe_monitor_pulse(){
 
     if(test){
       add_monitor(NULL,"PulseAudio",id);
+      ao_close(test);
+    }
+  }
+}
+
+static void output_probe_monitor_macosx(){
+  /* does this AO even have pulse output? */
+  int id = ao_driver_id("macosx");
+  if(id>=0){
+    /* test open; format doesn't matter */
+    ao_sample_format format={16,48000,2,AO_FMT_NATIVE,NULL};
+    ao_option opt={"client_name","postfish",NULL};
+    ao_device *test=ao_open_live(id, &format, &opt);
+
+    if(test){
+      add_monitor(NULL,"MacOSX",id);
       ao_close(test);
     }
   }
@@ -534,7 +550,11 @@ int output_probe_monitor(void ){
     return 0;
   }
 
+  #ifdef __APPLE_
   output_probe_monitor_pulse();
+  #else
+  output_probe_monitor_macosx();
+  #endif
   {
     int n = monitor_entries;
     output_probe_monitor_ALSA();

--- a/output.c
+++ b/output.c
@@ -508,7 +508,7 @@ static void output_probe_monitor_ALSA(){
 
 static void output_probe_monitor_pulse(){
   /* does this AO even have pulse output? */
-  int id = ao_driver_id("macosx");
+  int id = ao_driver_id("pulse");
   if(id>=0){
     /* test open; format doesn't matter */
     ao_sample_format format={16,48000,2,AO_FMT_NATIVE,NULL};

--- a/postfish.h
+++ b/postfish.h
@@ -140,6 +140,19 @@ static inline void underguard(float *x){
 
 #endif
 
+/* on OSX, there is no long double version of M_PI */
+#ifndef M_PIl
+#define M_PIl M_PI
+#endif
+
+#ifndef PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP
+#define PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP PTHREAD_RECURSIVE_MUTEX_INITIALIZER
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 8192
+#endif
+
 #ifndef max
 #define max(x,y) ((x)>(y)?(x):(y))
 #endif

--- a/version.h
+++ b/version.h
@@ -1,2 +1,2 @@
 #define VERSION "$Id$ "
-/* DO NOT EDIT: Automated versioning hack [So  3 Mär 2019 10:18:26 CET] */
+/* DO NOT EDIT: Automated versioning hack [So  3 Mär 2019 10:38:15 CET] */

--- a/version.h
+++ b/version.h
@@ -1,2 +1,2 @@
 #define VERSION "$Id$ "
-/* DO NOT EDIT: Automated versioning hack [Tue Jul 22 15:03:38 EDT 2014] */
+/* DO NOT EDIT: Automated versioning hack [So  3 Mär 2019 10:18:26 CET] */


### PR DESCRIPTION
I managed to compile postfish on OSX High Sierra. Generally, postfish works - I tried it with a few simple wav files and filter settings.

Requirements: xquartz, gtk+, fftw, libao. Can be installed via

            brew install gtk+ fftw libao

TODO: Disabling floating point exceptions (see main.c diff). 



